### PR TITLE
Fix configuration file schema doc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ Or put your file to `drizzle.config.json` configuration file:
 ```json
 {
   "out": "./migrations-folder",
-  "schema": "./src/db"
+  "schema": "./src/db/schema.ts"
 }
 ```
 


### PR DESCRIPTION
Just to be like the cmd line example.

NB: I have a `migrate` script in `./src/db` and `npx drizzle-kit generate:pg` runs everything in `schema` path 😅