### PR TITLE
Remove check:mysql command from docs, command doesn't exist

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -218,7 +218,6 @@ drizzle-kit up:mysql --out=migrations/
 ---
 
 **`$ drizzle-kit check:pg`** \
-**`$ drizzle-kit check:mysql`** \
 **`$ drizzle-kit check:sqlite`**
 
 `--out` [optional] migration folder\


### PR DESCRIPTION
Noticed that the doc includes a `check:mysql` CLI command that doesn't seem to exist.

I can't find the drizzle-kit source to be 100% sure it doesn't exist, but the CLI output indicates it doesn't:
```shell
error: unknown command 'check:mysql'
```